### PR TITLE
update docker image to 11.0.11-9-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:9-slim
+FROM openjdk:11.0.11-9-slim
 
 LABEL maintainer="e-COSI <tech@e-cosi.com>"
 


### PR DESCRIPTION
Attempted to run the original docker image jecosi/bastillion with the quickstart instructions. However, when trying to add servers in the web app I would get several java related errors. After several attempts, I decided to try re-building the docker image myself. 

However, the docker image was really old, so I updated the Dockercompose file to 11.0.11-9-slim.

The new docker image was build using: 
```
make build
```

And I was successful in running the application.
